### PR TITLE
feat: add Windsurf/Kiro editor compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "icon": "assets/icon-128.png",
   "engines": {
-    "vscode": "^1.92.0"
+    "vscode": "^1.107.0"
   },
   "categories": [
     "Debuggers",
@@ -338,7 +338,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.0",
-    "@types/vscode": "^1.92.0",
+    "@types/vscode": "^1.107.0",
     "esbuild": "^0.27.4",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "icon": "assets/icon-128.png",
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.92.0"
   },
   "categories": [
     "Debuggers",
@@ -338,7 +338,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.0",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.92.0",
     "esbuild": "^0.27.4",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "icon": "assets/icon-128.png",
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.85.0"
   },
   "categories": [
     "Debuggers",
@@ -338,7 +338,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.0",
-    "@types/vscode": "^1.110.0",
+    "@types/vscode": "^1.85.0",
     "esbuild": "^0.27.4",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.6",


### PR DESCRIPTION
Lower VSCode engine requirement from ^1.110.0 to ^1.85.0 to support Windsurf 1.108.x. Update @types/vscode dependency to match.

This change maintains backward compatibility with VSCode 1.85.0+ while enabling the extension to work in Windsurf editor without any code changes.

Addressed https://github.com/NovelBits/logscope/issues/4.

Tested latest .VSIX package and working fine across VSCode, Windsurf, Kiro editors and working fine.