### PR TITLE
log message should use fixed-width font

### DIFF
--- a/src/ui/webview/styles.css
+++ b/src/ui/webview/styles.css
@@ -275,7 +275,7 @@ body { display: flex; flex-direction: column; }
 .log-row .ts { color: var(--vscode-descriptionForeground, #888); margin-right: 10px; flex-shrink: 0; min-width: 100px; }
 .log-row .sev { font-weight: 700; margin-right: 8px; flex-shrink: 0; min-width: 32px; text-align: center; }
 .log-row .mod { color: var(--vscode-textLink-foreground, #3794ff); margin-right: 10px; flex-shrink: 0; min-width: 90px; overflow: hidden; text-overflow: ellipsis; }
-.log-row .msg { flex: 1; overflow: hidden; text-overflow: ellipsis; }
+.log-row .msg { font-family: var(--vscode-editor-font-family); flex: 1; overflow: hidden; text-overflow: ellipsis; }
 
 .log-row.hci .sev { color: #c586c0; }
 .log-row.hci { border-left: 3px solid #c586c0; }


### PR DESCRIPTION
Use --vscode-editor-font-family to ensure log messages use fixed-width font since log messages tend to heavily rely on monospace spacing.

<img width="1158" height="474" alt="image" src="https://github.com/user-attachments/assets/98737110-dd0e-446a-ae94-3fddd57606fc" />

<img width="1173" height="487" alt="image" src="https://github.com/user-attachments/assets/0a84e85d-2876-4e62-8b88-6f4ddc9b8083" />
