### PR TITLE
Preserve logs when moving LogScope tab between windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,6 +233,31 @@ function disconnectAll(): void {
   panel?.updateStatus(false, ringBuffer?.size ?? 0, ringBuffer?.evictedCount ?? 0);
 }
 
+function restorePanelFromSession(): void {
+  if (!panel) return;
+
+  // Re-send the current connection header in case this is a recreated webview.
+  if (transport?.connected) {
+    const currentParser = vscode.workspace.getConfiguration("logscope").get<string>("parser", "zephyr");
+    panel.sendConnected(
+      sidebarProvider.connectedTransportLabel,
+      sidebarProvider.connectedAddress,
+      currentParser,
+    );
+  }
+
+  const allEntries = ringBuffer?.getAll() ?? [];
+  if (allEntries.length > 0) {
+    const REPLAY_CHUNK_SIZE = 1000;
+    for (let i = 0; i < allEntries.length; i += REPLAY_CHUNK_SIZE) {
+      panel.addEntries(allEntries.slice(i, i + REPLAY_CHUNK_SIZE));
+    }
+  }
+
+  panel.updateModules(session ? Array.from(session.modules) : []);
+  panel.updateStatus(transport?.connected ?? false, ringBuffer?.size ?? 0, ringBuffer?.evictedCount ?? 0);
+}
+
 function handleErrorAction(action: ErrorAction): void {
   switch (action.command) {
     case "rescan":
@@ -1248,6 +1273,9 @@ export function activate(context: vscode.ExtensionContext) {
   log(`LogScope ${context.extension.packageJSON.version} activated on ${process.platform} (${process.arch})`);
 
   panel = new LogScopePanel(context.extensionUri);
+  panel.setReadyHandler(() => {
+    restorePanelFromSession();
+  });
   statusBar = new StatusBar();
   sidebarProvider.version = context.extension.packageJSON.version;
 

--- a/src/ui/webview-provider.ts
+++ b/src/ui/webview-provider.ts
@@ -19,11 +19,13 @@ interface SerializedEntry {
 
 /** Callback when the WebView sends a message back */
 export type WebViewMessageHandler = (msg: { type: string; [key: string]: unknown }) => void;
+export type WebViewReadyHandler = () => void;
 
 export class LogScopePanel {
   private panel: vscode.WebviewPanel | null = null;
   private readonly extensionUri: vscode.Uri;
   private onMessage: WebViewMessageHandler | null = null;
+  private onReady: WebViewReadyHandler | null = null;
 
   // Batching: accumulate entries and flush at ~60 fps
   private pendingEntries: SerializedEntry[] = [];
@@ -41,6 +43,11 @@ export class LogScopePanel {
   /** Register a handler for messages coming FROM the WebView */
   setMessageHandler(handler: WebViewMessageHandler): void {
     this.onMessage = handler;
+  }
+
+  /** Register a handler for when the WebView reports it is ready */
+  setReadyHandler(handler: WebViewReadyHandler): void {
+    this.onReady = handler;
   }
 
   /** Show or reveal the panel. Always opens in viewer mode. */
@@ -74,6 +81,7 @@ export class LogScopePanel {
           this.panel?.webview.postMessage(queued);
         }
         this.messageQueue = [];
+        this.onReady?.();
         return;
       }
       if (this.onMessage) {


### PR DESCRIPTION
Add webview-ready callback to LogScopePanel so the extension can restore buffered logs when a fresh webview is created. When the webview signals readiness, restorePanelFromSession() replays the ring buffer, module list, and connection status, ensuring logs remain visible after tab/window moves.