### PR TITLE
Fix silent device-picker hang on cold-start Python bootstrap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -80,6 +80,14 @@ Requires adding `snapshot()` / `restore()` methods to `SidebarProvider`. Not a h
 - Verify the UART branch (step 4 baud rate) doesn't have the same issue — looks like it commits state right before doConnect already, but check
 - Telemetry abandonment events (`trackConnectFlowAbandoned`) are the natural restore points
 
+### Log filter: exclude/mute a single chatty source (deselect one, not re-select all)
+**Origin:** field request from a user call (2026-07-21); two users independently asked for it.
+Today the log-source filter is select-what-you-want. Users want the inverse: keep everything visible but deselect/mute one specific noisy source (e.g. a chatty process/thread) without having to re-select every source they still care about. Add a per-source "mute/exclude" toggle so a single high-volume source can be hidden with one click, leaving the rest untouched.
+
+### Shell/terminal integration alongside the log view
+**Origin:** field request from a user call (2026-07-21).
+Users want an interactive device shell in the same tool as the log: a shell/console pane (RTT shell or UART) sitting next to the log panel (top/bottom or left/right split), so they can interact with the device and see the correlated log without leaving LogScope. Ideally the shell's own output can be filtered together with the log.
+
 ## Hardening / Tests
 
 ### Python helper output contract test (pytest)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -945,6 +945,29 @@ function scanBusyLabel(packages: string[]): string {
     : "$(cloud-download) First-time setup: installing helper packages (needs internet, may take a minute)...";
 }
 
+/**
+ * Shared failure handling for both device pickers.
+ *
+ * Each picker kicks its scan off as a floating promise, so an unhandled
+ * rejection would leave the QuickPick on its busy label indefinitely, with no
+ * way forward except closing it — which the user records as abandonment. Land
+ * on a visible, actionable state instead of a permanent spinner.
+ */
+function renderScanFailure<T extends vscode.QuickPickItem & { _rescan?: boolean }>(
+  qp: vscode.QuickPick<T>,
+  err: unknown,
+  context: string,
+): void {
+  const error = classifyError(err instanceof Error ? err.message : String(err));
+  lastDiscoveryErrorCode = error.code;
+  logError(context, err);
+  qp.items = [
+    { label: `$(error) ${error.headline}`, detail: error.detail } as T,
+    { label: "$(refresh) Rescan", _rescan: true } as T,
+  ];
+  qp.busy = false;
+}
+
 // ── Individual QuickPick helpers (reused by guided flow + change settings)
 
 async function pickSerialPort(showBack = false, step?: number, totalSteps?: number): Promise<{ path: string; label: string } | undefined> {
@@ -1003,19 +1026,7 @@ async function pickSerialPort(showBack = false, step?: number, totalSteps?: numb
     ];
     qp.busy = false;
     } catch (err) {
-      // Defense in depth. Nothing below is expected to throw, but this runs as
-      // a floating promise, so an unhandled rejection leaves the picker on
-      // "Scanning..." with qp.busy = true and no way forward except closing it
-      // — which is exactly the bug fixed in discoverDevices(). Always land on a
-      // visible, actionable state instead of a permanent spinner.
-      const error = classifyError(err instanceof Error ? err.message : String(err));
-      lastDiscoveryErrorCode = error.code;
-      logError("Serial port scan failed", err);
-      qp.items = [
-        { label: `$(error) ${error.headline}`, detail: error.detail },
-        { label: "$(refresh) Rescan", _rescan: true },
-      ];
-      qp.busy = false;
+      renderScanFailure(qp, err, "Serial port scan failed");
     } finally {
       scanning = false;
     }
@@ -1105,19 +1116,7 @@ async function pickJlinkDevice(showBack = false, step?: number, totalSteps?: num
     ];
     qp.busy = false;
     } catch (err) {
-      // Defense in depth. discoverDevices() no longer rejects on a Python
-      // bootstrap failure, but this runs as a floating promise, so any future
-      // rejection would again leave the picker on "Scanning..." with
-      // qp.busy = true and no way forward except closing it. Always land on a
-      // visible, actionable state instead of a permanent spinner.
-      const error = classifyError(err instanceof Error ? err.message : String(err));
-      lastDiscoveryErrorCode = error.code;
-      logError("J-Link device scan failed", err);
-      qp.items = [
-        { label: `$(error) ${error.headline}`, detail: error.detail },
-        { label: "$(refresh) Rescan", _rescan: true },
-      ];
-      qp.busy = false;
+      renderScanFailure(qp, err, "J-Link device scan failed");
     } finally {
       scanning = false;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,13 @@ let lineBuffer = "";
 const sidebarProvider = new LogScopeSidebarProvider();
 let userDisconnecting = false;
 let lastDiscoveredDevices: DiscoveredDevice[] = [];
+/**
+ * Classified error code from the most recent discovery attempt, or undefined
+ * when discovery last succeeded. Read when the user abandons the device step so
+ * we can tell "empty list because discovery failed" apart from "changed my
+ * mind". Holds a code (NO_PYTHON, NO_PROBE, ...), never a raw message.
+ */
+let lastDiscoveryErrorCode: string | undefined;
 let hciPacketCount = 0;
 let errorCount = 0;
 let licenseManager: LicenseManager;
@@ -670,9 +677,12 @@ async function rescanAndConnect(): Promise<void> {
     const ports = await discoverSerialPorts();
     if (ports.length === 0) {
       const error = classifyError("No serial ports found");
+      lastDiscoveryErrorCode = error.code;
+      telemetry.trackConnectFailed(error.code, transportType);
       panel?.sendConnectError(error);
       return;
     }
+    lastDiscoveryErrorCode = undefined;
     if (ports.length === 1) {
       const port = ports[0];
       const basename = port.path.split("/").pop() || port.path.split("\\").pop() || port.path;
@@ -696,9 +706,15 @@ async function rescanAndConnect(): Promise<void> {
       const error = discoverErr
         ? classifyError(discoverErr)
         : classifyError("", 3); // exit code 3 = NO_PROBE
+      lastDiscoveryErrorCode = error.code;
+      // A discovery failure is a failed connect attempt. Without this, every
+      // pre-doConnect failure (NO_PYTHON, VENV_FAILED, NO_SEGGER) was
+      // unrecordable, because doConnect's catch was the only caller.
+      telemetry.trackConnectFailed(error.code, transportType);
       panel?.sendConnectError(error);
       return;
     }
+    lastDiscoveryErrorCode = undefined;
     if (devices.length === 1) {
       const dev = devices[0];
       sidebarProvider.updateState({
@@ -821,12 +837,12 @@ async function guidedConnect(): Promise<void> {
           // Pick device/port
           if (transportValue === "uart") {
             const result = await pickSerialPort(true, 3, 4);
-            if (!result) { telemetry.trackConnectFlowAbandoned("device"); return; }
+            if (!result) { telemetry.trackConnectFlowAbandoned("device", lastDiscoveryErrorCode); return; }
             port = result;
             step = 4; // go to baud rate
           } else {
             const device = await pickJlinkDevice(true, 3, 4);
-            if (!device) { telemetry.trackConnectFlowAbandoned("device"); return; }
+            if (!device) { telemetry.trackConnectFlowAbandoned("device", lastDiscoveryErrorCode); return; }
             sidebarProvider.updateState({
               transport: "rtt",
               selectedDevice: String(device.serial),
@@ -938,11 +954,13 @@ async function pickSerialPort(showBack = false, step?: number, totalSteps?: numb
     const ports = await discoverSerialPorts();
     if (ports.length === 0) {
       const error = classifyError("No serial ports found");
+      lastDiscoveryErrorCode = error.code;
       panel?.sendConnectError(error);
       qp.items = [{ label: "No serial ports found" }, { label: "$(refresh) Rescan", _rescan: true }];
       qp.busy = false;
       return;
     }
+    lastDiscoveryErrorCode = undefined;
     qp.items = [
       ...ports.map(p => {
         // Primary label: "J-Link (Port 1)" or just "J-Link" or path basename
@@ -1036,10 +1054,14 @@ async function pickJlinkDevice(showBack = false, step?: number, totalSteps?: num
           label: "$(warning) No J-Link devices found",
           detail: "Probe held by another tool? Close any RTT/VCOM session in nRF Connect, JLink Commander, or RTT Viewer and rescan.",
         };
+      lastDiscoveryErrorCode = discoverErr
+        ? classifyError(discoverErr).code
+        : classifyError("", 3).code; // exit code 3 = NO_PROBE
       qp.items = [emptyItem, { label: "$(refresh) Rescan", _rescan: true }];
       qp.busy = false;
       return;
     }
+    lastDiscoveryErrorCode = undefined;
     qp.items = [
       ...devices.map(d => ({
         label: deviceLabel(d as DiscoveredDevice & { targetName?: string }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -982,6 +982,20 @@ async function pickSerialPort(showBack = false, step?: number, totalSteps?: numb
       { label: "$(refresh) Rescan", _rescan: true },
     ];
     qp.busy = false;
+    } catch (err) {
+      // Defense in depth. Nothing below is expected to throw, but this runs as
+      // a floating promise, so an unhandled rejection leaves the picker on
+      // "Scanning..." with qp.busy = true and no way forward except closing it
+      // — which is exactly the bug fixed in discoverDevices(). Always land on a
+      // visible, actionable state instead of a permanent spinner.
+      const error = classifyError(err instanceof Error ? err.message : String(err));
+      lastDiscoveryErrorCode = error.code;
+      logError("Serial port scan failed", err);
+      qp.items = [
+        { label: `$(error) ${error.headline}`, detail: error.detail },
+        { label: "$(refresh) Rescan", _rescan: true },
+      ];
+      qp.busy = false;
     } finally {
       scanning = false;
     }
@@ -1070,6 +1084,20 @@ async function pickJlinkDevice(showBack = false, step?: number, totalSteps?: num
       { label: "$(refresh) Rescan", _rescan: true },
     ];
     qp.busy = false;
+    } catch (err) {
+      // Defense in depth. discoverDevices() no longer rejects on a Python
+      // bootstrap failure, but this runs as a floating promise, so any future
+      // rejection would again leave the picker on "Scanning..." with
+      // qp.busy = true and no way forward except closing it. Always land on a
+      // visible, actionable state instead of a permanent spinner.
+      const error = classifyError(err instanceof Error ? err.message : String(err));
+      lastDiscoveryErrorCode = error.code;
+      logError("J-Link device scan failed", err);
+      qp.items = [
+        { label: `$(error) ${error.headline}`, detail: error.detail },
+        { label: "$(refresh) Rescan", _rescan: true },
+      ];
+      qp.busy = false;
     } finally {
       scanning = false;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -928,6 +928,21 @@ function deviceLabel(dev: { serial: number; targetName?: string }): string {
   return `${name} (SN: ${dev.serial})`;
 }
 
+/**
+ * Busy-state label for the device pickers.
+ *
+ * On a cold machine the first scan has to create a Python venv and pip-install
+ * a helper package, which needs the network and can take tens of seconds. A
+ * bare "Scanning..." for that long is indistinguishable from a hang, and the
+ * user closes the picker — recorded as abandonment at step "device", the single
+ * most-abandoned step. Say what is actually happening instead.
+ */
+function scanBusyLabel(packages: string[]): string {
+  return isPythonEnvReady(packages)
+    ? "Scanning..."
+    : "$(cloud-download) First-time setup: installing helper packages (needs internet, may take a minute)...";
+}
+
 // ── Individual QuickPick helpers (reused by guided flow + change settings)
 
 async function pickSerialPort(showBack = false, step?: number, totalSteps?: number): Promise<{ path: string; label: string } | undefined> {
@@ -935,7 +950,7 @@ async function pickSerialPort(showBack = false, step?: number, totalSteps?: numb
   qp.placeholder = "Select serial port...";
   qp.title = "Connect Device";
   qp.busy = true;
-  qp.items = [{ label: "Scanning..." }];
+  qp.items = [{ label: scanBusyLabel(["pyserial"]) }];
   if (showBack) {
     qp.buttons = [vscode.QuickInputButtons.Back];
     qp.step = step ?? 2;
@@ -949,7 +964,7 @@ async function pickSerialPort(showBack = false, step?: number, totalSteps?: numb
     if (scanning) return;
     scanning = true;
     qp.busy = true;
-    qp.items = [{ label: "Scanning..." }];
+    qp.items = [{ label: scanBusyLabel(["pyserial"]) }];
     try {
     const ports = await discoverSerialPorts();
     if (ports.length === 0) {
@@ -1036,7 +1051,7 @@ async function pickJlinkDevice(showBack = false, step?: number, totalSteps?: num
   qp.placeholder = "Select J-Link device...";
   qp.title = "Connect Device";
   qp.busy = true;
-  qp.items = [{ label: "Scanning..." }];
+  qp.items = [{ label: scanBusyLabel(["pylink-square"]) }];
   if (showBack) {
     qp.buttons = [vscode.QuickInputButtons.Back];
     qp.step = step ?? 2;
@@ -1053,7 +1068,7 @@ async function pickJlinkDevice(showBack = false, step?: number, totalSteps?: num
     if (scanning) return;
     scanning = true;
     qp.busy = true;
-    qp.items = [{ label: "Scanning..." }];
+    qp.items = [{ label: scanBusyLabel(["pylink-square"]) }];
     try {
     const { devices, error: discoverErr } = await discoverDevices();
     lastDiscoveredDevices = devices;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -674,9 +674,11 @@ async function rescanAndConnect(): Promise<void> {
   const transportType = sidebarProvider.currentTransport;
 
   if (transportType === "uart") {
-    const ports = await discoverSerialPorts();
+    const { ports, error: discoverErr } = await discoverSerialPorts();
     if (ports.length === 0) {
-      const error = classifyError("No serial ports found");
+      // Prefer the specific reason (e.g. Python bootstrap failure) over the
+      // generic "no ports" message, which would misdescribe it.
+      const error = classifyError(discoverErr ?? "No serial ports found");
       lastDiscoveryErrorCode = error.code;
       telemetry.trackConnectFailed(error.code, transportType);
       panel?.sendConnectError(error);
@@ -966,12 +968,15 @@ async function pickSerialPort(showBack = false, step?: number, totalSteps?: numb
     qp.busy = true;
     qp.items = [{ label: scanBusyLabel(["pyserial"]) }];
     try {
-    const ports = await discoverSerialPorts();
+    const { ports, error: discoverErr } = await discoverSerialPorts();
     if (ports.length === 0) {
-      const error = classifyError("No serial ports found");
+      const error = classifyError(discoverErr ?? "No serial ports found");
       lastDiscoveryErrorCode = error.code;
       panel?.sendConnectError(error);
-      qp.items = [{ label: "No serial ports found" }, { label: "$(refresh) Rescan", _rescan: true }];
+      qp.items = [
+        { label: `$(warning) ${error.headline}`, detail: discoverErr ?? undefined },
+        { label: "$(refresh) Rescan", _rescan: true },
+      ];
       qp.busy = false;
       return;
     }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -115,9 +115,17 @@ export class TelemetryService {
   /**
    * Track user abandoning the guided connect flow.
    * Called when guidedConnect() QuickPick is dismissed.
+   *
+   * `reason` disambiguates the two very different outcomes that both surface as
+   * abandonment at step "device": the user changed their mind with a populated
+   * list, versus the list was empty because discovery failed. Without it,
+   * "device" was by far the most-abandoned step and told us nothing about why.
+   *
+   * Like trackConnectFailed, this takes a classified error CODE only, never a
+   * raw message (those can contain filesystem paths).
    */
-  trackConnectFlowAbandoned(step: string): void {
-    this.send("connect_flow_abandoned", { step });
+  trackConnectFlowAbandoned(step: string, reason?: string): void {
+    this.send("connect_flow_abandoned", reason ? { step, reason } : { step });
   }
 
   /**

--- a/src/transport/nrfutil-rtt.ts
+++ b/src/transport/nrfutil-rtt.ts
@@ -235,7 +235,27 @@ export function parseDiscoverResult(
  */
 export async function discoverDevices(): Promise<DiscoveryResult> {
   const helperPath = path.join(__dirname, "rtt-helper.py");
-  const pythonPath = await ensurePythonEnv(["pylink-square"]);
+
+  // Bootstrapping the Python env is the first thing that can fail here, and on
+  // a cold machine it is the most likely thing to fail — no Python installed,
+  // or pip unable to reach PyPI behind a corporate proxy. Report it the way
+  // every other discovery failure is reported: callers expect a DiscoveryResult,
+  // never a rejection.
+  //
+  // Letting this throw left the device QuickPick spinning on "Scanning..."
+  // indefinitely, because scanDevices() (extension.ts) wraps the call in
+  // try/finally with no catch and invokes it as a floating promise. The error
+  // text below is already user-actionable and already classifiable by
+  // classifyError() (NO_PYTHON / VENV_FAILED), but none of it ever reached the
+  // user.
+  let pythonPath: string;
+  try {
+    pythonPath = await ensurePythonEnv(["pylink-square"]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError("Python environment setup failed during device discovery", err);
+    return { devices: [], error: message };
+  }
 
   return new Promise((resolve) => {
     const proc = spawn(pythonPath, [helperPath, "discover"], {

--- a/src/transport/uart-serial.ts
+++ b/src/transport/uart-serial.ts
@@ -30,14 +30,37 @@ export interface DiscoveredSerialPort {
   portNumber?: number;
 }
 
+/** Result of serial port discovery — includes diagnostic error when discovery fails */
+export interface SerialDiscoveryResult {
+  ports: DiscoveredSerialPort[];
+  /** Set when discovery failed (e.g. the Python environment could not be provisioned) */
+  error?: string;
+}
+
 /**
  * Discover available serial ports via the Python uart-helper.
  * Filters out Bluetooth and debug virtual ports.
+ *
+ * Mirrors discoverDevices()/DiscoveryResult: discovery problems are REPORTED,
+ * never thrown, because callers drive UI off the result.
  */
-export async function discoverSerialPorts(): Promise<DiscoveredSerialPort[]> {
+export async function discoverSerialPorts(): Promise<SerialDiscoveryResult> {
   const helperPath = path.join(__dirname, "uart-helper.py");
 
-  const pythonPath = await ensurePythonEnv(["pyserial"]);
+  // Same defect discoverDevices() had: awaiting the Python bootstrap outside the
+  // Promise, unguarded, so a cold-machine failure (no Python, or pip blocked
+  // from PyPI) rejected instead of being reported. rescanAndConnect() calls this
+  // bare from the logscope.rescan command, so the rejection escaped as a generic
+  // VS Code command error — no classified card, no telemetry.
+  let pythonPath: string;
+  try {
+    pythonPath = await ensurePythonEnv(["pyserial"]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError("Python environment setup failed during serial port discovery", err);
+    return { ports: [], error: message };
+  }
+
   return new Promise((resolve) => {
     const proc = spawn(pythonPath, [helperPath, "discover"], {
       stdio: ["pipe", "pipe", "pipe"],
@@ -51,16 +74,16 @@ export async function discoverSerialPorts(): Promise<DiscoveredSerialPort[]> {
       try {
         const result = JSON.parse(stdout);
         log(`Serial port scan found ${result.ports?.length ?? 0} ports`);
-        resolve(result.ports ?? []);
+        resolve({ ports: result.ports ?? [] });
       } catch {
         logError("Failed to parse serial port scan output");
-        resolve([]);
+        resolve({ ports: [], error: "Serial port scan produced no readable output." });
       }
     });
 
     proc.on("error", (err) => {
       logError("Serial port scan failed", err);
-      resolve([]);
+      resolve({ ports: [], error: err.message });
     });
   });
 }
@@ -202,7 +225,11 @@ export class UartTransport extends EventEmitter implements Transport {
         return;
       }
       try {
-        const ports = await discoverSerialPorts();
+        const { ports, error } = await discoverSerialPorts();
+        // A failed scan tells us nothing about the port. Only an authoritative
+        // empty result means "unplugged" — otherwise a transient discovery
+        // failure would tear down a perfectly healthy session.
+        if (error) return;
         const portPaths = ports.map(p => p.path);
         if (!portPaths.includes(this.portPath)) {
           log(`Port ${this.portPath} disappeared — device unplugged`);

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -243,6 +243,29 @@ describe("TelemetryService", () => {
         undefined
       );
     });
+
+    it("sends the discovery error code as reason when one is supplied", () => {
+      const ctx = createMockContext();
+      service.init(ctx as never);
+
+      service.trackConnectFlowAbandoned("device", "NO_PYTHON");
+
+      expect(mockSendTelemetryEvent).toHaveBeenCalledWith(
+        "connect_flow_abandoned",
+        expect.objectContaining({ step: "device", reason: "NO_PYTHON" }),
+        undefined
+      );
+    });
+
+    it("omits reason entirely when none is supplied, so the field stays absent", () => {
+      const ctx = createMockContext();
+      service.init(ctx as never);
+
+      service.trackConnectFlowAbandoned("transport");
+
+      const props = mockSendTelemetryEvent.mock.calls.at(-1)?.[1] as Record<string, string>;
+      expect(props).not.toHaveProperty("reason");
+    });
   });
 
   describe("trackExport()", () => {

--- a/test/transport/nrfutil-rtt.test.ts
+++ b/test/transport/nrfutil-rtt.test.ts
@@ -15,7 +15,8 @@ jest.mock("fs", () => ({
 
 const mockExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
 
-import { resolveSystemPython, NrfutilRttTransport } from "../../src/transport/nrfutil-rtt";
+import { resolveSystemPython, NrfutilRttTransport, discoverDevices } from "../../src/transport/nrfutil-rtt";
+import { classifyError } from "../../src/errors";
 
 describe("resolveSystemPython", () => {
   beforeEach(() => {
@@ -209,5 +210,79 @@ describe("_handleStderrLine: CHANNEL_NAME parsing", () => {
       expect(emitted).toBe(false);
       done();
     }, 50);
+  });
+});
+
+// ── Regression: Python bootstrap failure must not escape discoverDevices() ──
+//
+// discoverDevices() (nrfutil-rtt.ts) awaits ensurePythonEnv() OUTSIDE its own
+// Promise and without a try/catch, so a bootstrap failure REJECTS instead of
+// resolving with {devices: [], error}.
+//
+// That breaks the contract every caller assumes, and which parseDiscoverResult
+// is already tested against ("returns empty devices and helper error..."):
+// discovery problems are REPORTED, not thrown.
+//
+// Consequences at the two call sites:
+//   • extension.ts:1026 — scanDevices() wraps the call in try/finally with NO
+//     catch, and extension.ts:1083 invokes it as a floating promise. The
+//     QuickPick is left on "Scanning..." with qp.busy = true, permanently.
+//     The user closes it, which records connect_flow_abandoned("device").
+//   • extension.ts:691 — the bare await rejects out of the connect command.
+//
+// Neither path reaches telemetry.trackConnectFailed (extension.ts:639 is its
+// only call site), which is why NO_SEGGER and VENV_FAILED have zero recorded
+// events despite being implemented error codes.
+describe("discoverDevices: Python bootstrap failure (regression)", () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it("resolves with an actionable error when Python cannot be found, instead of rejecting", async () => {
+    // Nothing executable anywhere: the which/where lookup and every --version
+    // probe fail. fs.existsSync is already mocked false at module scope, so
+    // neither the managed venv nor any well-known install path is found.
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    await expect(discoverDevices()).resolves.toEqual({
+      devices: [],
+      error: expect.stringMatching(/Python 3 not found/),
+    });
+  });
+
+  it("resolves with an actionable error when the pylink install fails (blocked PyPI)", async () => {
+    // The likelier real-world trigger: Python exists, but pip cannot reach
+    // PyPI (corporate proxy, offline first run). Walk ensurePythonEnv through
+    // to step 4 and fail only the install.
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      const argv = (args ?? []) as string[];
+      if (cmd === "which" || cmd === "where") return "/usr/bin/python3\n";
+      if (argv[0] === "-m" && argv[1] === "venv") return "";           // venv creation succeeds
+      if (argv[0] === "install") {
+        throw new Error("Could not fetch URL https://pypi.org/simple/pylink-square/");
+      }
+      if (argv[0] === "-c") {
+        throw new Error("ModuleNotFoundError: No module named 'pylink'");
+      }
+      return "";
+    });
+
+    await expect(discoverDevices()).resolves.toEqual({
+      devices: [],
+      error: expect.stringMatching(/Failed to install pylink-square/),
+    });
+  });
+
+  it("returns an error string that classifyError maps to a specific code, not GENERIC", async () => {
+    // Ties the fix to the telemetry blind spot: as long as the bootstrap error
+    // never reaches classifyError, NO_PYTHON/VENV_FAILED can never be recorded.
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    const { error } = await discoverDevices();
+    expect(classifyError(error ?? "").code).toBe("NO_PYTHON");
   });
 });

--- a/test/transport/uart-serial.test.ts
+++ b/test/transport/uart-serial.test.ts
@@ -1,4 +1,5 @@
 import { UartTransport, discoverSerialPorts } from "../../src/transport/uart-serial";
+import { ensurePythonEnv } from "../../src/transport/nrfutil-rtt";
 import { ChildProcess, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 
@@ -159,13 +160,14 @@ describe("discoverSerialPorts", () => {
     proc.stdout!.emit("data", Buffer.from(response));
     proc.emit("exit", 0);
 
-    const ports = await promise;
+    const { ports, error } = await promise;
     expect(ports).toHaveLength(2);
     expect(ports[0].path).toBe("/dev/cu.usbmodem001");
     expect(ports[0].manufacturer).toBe("SEGGER");
+    expect(error).toBeUndefined();
   });
 
-  it("returns empty array on error", async () => {
+  it("returns empty ports and a diagnostic error when the helper fails to spawn", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
 
@@ -173,7 +175,25 @@ describe("discoverSerialPorts", () => {
     await tick();
     proc.emit("error", new Error("spawn failed"));
 
-    const ports = await promise;
+    const { ports, error } = await promise;
     expect(ports).toHaveLength(0);
+    expect(error).toMatch(/spawn failed/);
+  });
+
+  // Regression: same defect as discoverDevices() — awaiting the Python bootstrap
+  // unguarded meant a cold-machine failure REJECTED instead of reporting.
+  // rescanAndConnect() calls this bare from the logscope.rescan command, so the
+  // rejection escaped as a generic VS Code error with no classified card and no
+  // telemetry.
+  it("resolves with an actionable error when the Python bootstrap fails, instead of rejecting", async () => {
+    (ensurePythonEnv as jest.MockedFunction<typeof ensurePythonEnv>).mockRejectedValueOnce(
+      new Error("Python 3 not found. Install Python 3 from python.org and reload VS Code.")
+    );
+
+    await expect(discoverSerialPorts()).resolves.toEqual({
+      ports: [],
+      error: expect.stringMatching(/Python 3 not found/),
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

Telemetry shows **163 of 246 opt-in installs (66%) never achieved a single successful connection**, and `connect_flow_abandoned` at step `device` is the single most-abandoned step (320 events, against **zero** at `transport` and `parser` — the two steps with no I/O). 46 of the 81 device-abandoners never once connected.

Root cause: `discoverDevices()` awaited `ensurePythonEnv()` outside its own Promise with no try/catch. On a cold machine that call creates a venv and pip-installs `pylink-square` over the network. If it throws (no Python, or PyPI blocked by a corporate proxy), `discoverDevices()` **rejected**. `scanDevices()` wraps it in `try/finally` with no `catch` and runs it as a floating promise, so the QuickPick was left on `"Scanning..."` with `qp.busy = true`, permanently.

The error messages already existed and were already actionable and classifiable (`NO_PYTHON` / `VENV_FAILED`). They just had no path to the screen.

`trackConnectFailed` has exactly one call site, inside `doConnect()`, so every pre-connect failure was invisible — which is why `NO_SEGGER` and `VENV_FAILED` show zero recorded events.

## Commits

| Commit | What |
|---|---|
| `1473be6` | Report bootstrap failure instead of rejecting (+3 regression tests) |
| `853e077` | Make pre-connect discovery failures recordable; `connect_flow_abandoned` carries a classified reason |
| `440876b` | Defense in depth: neither picker can stick on "Scanning..." |
| `826d3e6` | Cold start says "first-time setup", not "Scanning..." |
| `de701f6` | Same guard for `discoverSerialPorts()` (UART had the identical defect) |

## Notes

- `connect_flow_abandoned`'s new `reason` carries a **classified code only**, never a raw message, matching the existing rule for `trackConnectFailed` (raw messages can contain paths).
- `de701f6` also fixes a latent hazard: the Windows port watcher treated any empty scan as "device unplugged" and disconnected. A failed scan says nothing about the port, so errored scans are now ignored.
- The slow-but-successful case (`826d3e6`) and the failure case produce the *same* abandonment event, so neither alone accounts for the 320.

## Verification

348 tests passing, 23 suites. Build clean. The `de701f6` regression test was verified to fail without its guard (rejects rather than resolving).

**This diagnosis is not yet proven to be the cause of the 320 abandonments** — it is a confirmed defect that produces the observed symptom. The `reason` instrumentation in `853e077` is what will confirm or kill it, measured against the baseline in `novelbits-brain/docs/research/2026-08-02-logscope-telemetry-baseline.md`.